### PR TITLE
修复无法正常添加headers的问题

### DIFF
--- a/src/Lite.php
+++ b/src/Lite.php
@@ -17,7 +17,7 @@ class Lite {
     );
 
     protected $flag = false;
-    
+
     public function __construct() {
         if(\PhalApi\DI()->config->get('app.cors'))
             $this->config = array_merge($this->config, \PhalApi\DI()->config->get('app.cors'));
@@ -33,10 +33,11 @@ class Lite {
         if($this->flag){
 
             $this->config['headers']['Access-Control-Allow-Origin'] = $origin;
-            $this->config['headers']['Access-Control-Allow-Headers'] = 'Content-Type';
+            $this->config['headers']['Access-Control-Allow-Headers'] = $this->config['headers']['Access-Control-Allow-Headers'] ? $this->config['headers']['Access-Control-Allow-Headers'] : 'Content-Type';
 
             foreach ($this->config['headers'] as $key => $val) {
                  \PhalApi\DI()->response->addHeaders($key,$val);
+                @header($key . ': ' . $val);
             }
         }
     }


### PR DESCRIPTION
当前版本无法正常添加headers，不支持自定义 Access-Control-Allow-Headers 。另外如果是OPTIONS请求，\PhalApi\DI()->response->addHeaders 无效